### PR TITLE
Add gst-plugins-bad in the dependency list in the README

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,7 @@
 We depend on the following gstreamer source modules:
 gstreamer
 gst-plugins-base
+gst-plugins-bad
 gst-plugins-good
 
 And in more detail, on the following plugins (this information may be useful if your distribution package the gstreamer plugins in a different way):


### PR DESCRIPTION
See full discussion on the [KDE bug](https://bugs.kde.org/show_bug.cgi?id=356133). Short version is that kamoso segfaults without it because _wrappercamerabinsrc_ is in the bad plugins now.

I had also uploaded a patch on the bugtracker to exit cleanly instead of segfaulting, I will send it after this unless you have objections.
